### PR TITLE
Update README.md fixing url typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,6 @@ const canary = new ZeebeCanary({
 })
 ```
 
-If you use an external healthcheck ping like [healthchecks.io](healthchecks.io) for the `ChirpUrl`, it will squawk if the canary does not chirp on time, _and_ if the canary process dies, so it will also alert you on client application failure.
+If you use an external healthcheck ping like [healthchecks.io](https://healthchecks.io) for the `ChirpUrl`, it will squawk if the canary does not chirp on time, _and_ if the canary process dies, so it will also alert you on client application failure.
 
 You can use your own `SquawkUrl`, and it will be pinged if the canary does not get a chirp task in 1.5x the heartbeat interval - but not if the canary process itself (your application) dies.


### PR DESCRIPTION
Just came across and got a 404 when visiting the linked site, since it was missing the protocol to be external.